### PR TITLE
refactor: Maximizer contracts

### DIFF
--- a/contracts/libs/IStrategyMaximizerMasterApe.sol
+++ b/contracts/libs/IStrategyMaximizerMasterApe.sol
@@ -60,4 +60,6 @@ interface IStrategyMaximizerMasterApe {
     function claimRewards(address _userAddress, uint256 _shares) external;
 
     function emergencyVaultWithdraw() external;
+
+    function emergencyBananaVaultWithdraw(address _to) external;
 }

--- a/contracts/maximizer/BaseBananaMaximizerStrategy.sol
+++ b/contracts/maximizer/BaseBananaMaximizerStrategy.sol
@@ -78,7 +78,7 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
     // Runtime data
     mapping(address => UserInfo) public userInfo; // Info of users
     uint256 public accSharesPerStakedToken; // Accumulated BANANA_VAULT shares per staked token, times 1e18.
-    uint256 private unallocatedShares;
+    uint256 public unallocatedShares;
 
     // Vault info
     address public immutable STAKE_TOKEN_ADDRESS;
@@ -138,7 +138,7 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
 
     function totalStake() public view virtual returns (uint256);
 
-    function emergencyVaultWithdraw() public virtual;
+    function _emergencyVaultWithdraw() internal virtual;
 
     function _vaultDeposit(uint256 _amount) internal virtual;
 
@@ -282,10 +282,14 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
         // Calculate the WBNB values
         keeperOutput = (wbnbOutput * settings.keeperFee) / 10000;
         // Calculate the BANANA values
-        platformOutput = (bananaOutputWithoutFees * settings.platformFee) / 10000;
+        platformOutput =
+            (bananaOutputWithoutFees * settings.platformFee) /
+            10000;
         burnOutput = (bananaOutputWithoutFees * settings.buyBackRate) / 10000;
-        uint256 bananaFees = 
-            ((bananaOutputWithoutFees * settings.keeperFee) / 10000) + platformOutput + burnOutput;
+        uint256 bananaFees = ((bananaOutputWithoutFees * settings.keeperFee) /
+            10000) +
+            platformOutput +
+            burnOutput;
         bananaOutput = bananaOutputWithoutFees - bananaFees;
     }
 
@@ -301,15 +305,16 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
             "BaseBananaMaximizerStrategy: amount must be greater than zero"
         );
         _beforeDeposit(_userAddress);
+        // Farm excess rewards
+        uint256 deposited = _farm();
         // Update userInfo
         UserInfo storage user = userInfo[_userAddress];
-        // Update autoBananaShares
+        // Add autoBananaShares earned banana since last action
         user.autoBananaShares +=
             ((user.stake * accSharesPerStakedToken) / 1e18) -
             user.rewardDebt;
-
-        uint256 deposited = _farm();
         user.stake += deposited;
+        // Reset the reward debt with the new stake to start earning rewards from here
         user.rewardDebt = (user.stake * accSharesPerStakedToken) / 1e18;
         user.lastDepositedTime = block.timestamp;
 
@@ -358,7 +363,6 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
         user.autoBananaShares +=
             ((user.stake * accSharesPerStakedToken) / 1e18) -
             user.rewardDebt;
-        // Setting order so that rewardDebt is zero when withdrawing all
         user.stake -= currentAmount;
         user.rewardDebt = (user.stake * accSharesPerStakedToken) / 1e18;
         // Withdraw banana rewards if user leaves
@@ -457,7 +461,23 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
             }
         }
         // Earns inside BANANA on deposits
-        _bananaVaultDeposit(false);
+        _bananaVaultDeposit(0, false);
+    }
+
+    /// @notice Handle emergency withdraw of this strategy without caring about rewards. EMERGENCY ONLY.
+    function emergencyVaultWithdraw() external onlyVaultApe {
+        // Remove farm tokens
+        _emergencyVaultWithdraw();
+    }
+
+    /// @notice Handle emergency withdraw of this strategy without caring about rewards. EMERGENCY ONLY.
+    /// @dev Transferring out all BANANA rewards will lock BANANA harvests. This contract can be filled up with
+    ///  excess needed BANANA or users can withdraw their stake and be airdropped BANANA tokens.
+    function emergencyBananaVaultWithdraw(address _to) external onlyVaultApe {
+        // Remove BANANA vault tokens
+        BANANA_VAULT.withdrawAll();
+        uint256 bananaBalance = _bananaBalance();
+        _safeBANANATransfer(_to, bananaBalance);
     }
 
     /// @notice getter function for settings
@@ -509,19 +529,16 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
         return actualSettings;
     }
 
-    function _farm() internal returns (uint256) {
+    function _farm() internal returns (uint256 _stakeTokensDeposited) {
         uint256 stakeTokenBalance = IERC20(STAKE_TOKEN).balanceOf(
             address(this)
         );
-        if (stakeTokenBalance == 0) return 0;
 
         uint256 stakeBefore = totalStake();
         _vaultDeposit(stakeTokenBalance);
+        _stakeTokensDeposited = totalStake() - stakeBefore;
         // accSharesPerStakedToken is updated here to ensure
-        _bananaVaultDeposit(true);
-        uint256 stakeAfter = totalStake();
-
-        return stakeAfter - stakeBefore;
+        _bananaVaultDeposit(_stakeTokensDeposited, true);
     }
 
     function _bananaVaultWithdraw(
@@ -547,8 +564,6 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
 
         uint256 pricePerFullShare = BANANA_VAULT.getPricePerFullShare();
         uint256 bananaToWithdraw = (currentShares * pricePerFullShare) / 1e18;
-        uint256 bananaBalance = _bananaBalance();
-        uint256 bananaShareBalance = (bananaBalance * 1e18) / pricePerFullShare;
         uint256 totalStrategyBanana = totalBanana();
 
         if (bananaToWithdraw > totalStrategyBanana) {
@@ -556,10 +571,8 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
             currentShares = (bananaToWithdraw * 1e18) / pricePerFullShare;
         }
 
-        if (currentShares > bananaShareBalance) {
-            BANANA_VAULT.withdraw(currentShares - bananaShareBalance);
-            bananaBalance = _bananaBalance();
-        }
+        BANANA_VAULT.withdraw(currentShares);
+        uint256 bananaBalance = _bananaBalance();
 
         if (bananaToWithdraw > bananaBalance) {
             bananaToWithdraw = bananaBalance;
@@ -578,32 +591,40 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
         emit ClaimRewards(_userAddress, currentShares, bananaToWithdraw);
     }
 
-    function _bananaVaultDeposit(bool _takeFee) internal {
+    function _bananaVaultDeposit(uint256 _depositedStakeTokens, bool _takeFee)
+        internal
+    {
         uint256 bananaBalance = _bananaBalance();
         if (bananaBalance == 0) {
             // earn
             BANANA_VAULT.deposit(0);
             return;
         }
-        uint256 previousShares = totalAutoBananaShares();
-        // Handle fee if needed
         IMaximizerVaultApe.Settings memory settings = getSettings();
-        if (_takeFee && settings.withdrawRewardsFee > 0) {
+        if (_takeFee && settings.platformFee > 0) {
             // This catches times when banana is deposited outside of earn and harvests are generated
-            uint256 bananaFee = (bananaBalance * settings.withdrawRewardsFee) /
-                10000;
+            uint256 bananaFee = (bananaBalance * settings.platformFee) / 10000;
             _safeBANANATransfer(settings.treasury, bananaFee);
             bananaBalance -= bananaFee;
         }
 
+        uint256 previousShares = totalAutoBananaShares();
         _approveTokenIfNeeded(BANANA, bananaBalance, address(BANANA_VAULT));
         BANANA_VAULT.deposit(bananaBalance);
+
+        /// To give correct token allocations to correct users. It's important to adjust the "Accumulated Shares Per Staked Token"
+        ///   value correctly as deposits and withdraws both simultaneously earn fees.
+        uint256 adjustedStake = totalStake() - _depositedStakeTokens;
+        if (adjustedStake == 0) {
+            // Catches scenarios where all stake is removed and there is dust in the strategy
+            return;
+        }
 
         uint256 currentShares = totalAutoBananaShares();
         uint256 shareIncrease = currentShares - previousShares;
 
         uint256 increaseAccSharesPerStakedToken = ((shareIncrease +
-            unallocatedShares) * 1e18) / totalStake();
+            unallocatedShares) * 1e18) / adjustedStake;
         accSharesPerStakedToken += increaseAccSharesPerStakedToken;
 
         // Not all shares are allocated because it's divided by totalStake() and can have rounding issue.
@@ -612,7 +633,7 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
         // From example: 45 missing shares still to be allocated
         unallocatedShares =
             (shareIncrease + unallocatedShares) -
-            ((increaseAccSharesPerStakedToken * totalStake()) / 1e18);
+            ((increaseAccSharesPerStakedToken * adjustedStake) / 1e18);
     }
 
     function _rewardTokenBalance() internal view returns (uint256) {
@@ -646,6 +667,25 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
             BANANA.transfer(_to, balance);
         } else {
             BANANA.transfer(_to, _amount);
+        }
+    }
+
+    /// @notice Provide a path and amount to find the expected output
+    /// @param _path Array of token addresses which compose the path from index 0 to n
+    /// @param _inputAmount Amount of tokens to provide for the swap
+    /// @return Reward output amount based on path
+    function _getExpectedOutputAmount(
+        address[] memory _path,
+        uint256 _inputAmount
+    ) internal view returns (uint256) {
+        if (_path.length <= 1 || _inputAmount == 0) {
+            return _inputAmount;
+        } else {
+            uint256[] memory amounts = router.getAmountsOut(
+                _inputAmount,
+                _path
+            );
+            return amounts[amounts.length - 1];
         }
     }
 

--- a/contracts/maximizer/BaseBananaMaximizerStrategy.sol
+++ b/contracts/maximizer/BaseBananaMaximizerStrategy.sol
@@ -356,7 +356,7 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
         ) {
             // Take withdraw fees
             withdrawFee = (currentAmount * settings.withdrawFee) / 10000;
-            STAKE_TOKEN.safeTransfer(settings.treasury, withdrawFee);
+            STAKE_TOKEN.safeTransfer(settings.platform, withdrawFee);
         }
         STAKE_TOKEN.safeTransfer(_userAddress, currentAmount - withdrawFee);
 
@@ -582,7 +582,7 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
             uint256 bananaFee = (bananaToWithdraw *
                 settings.withdrawRewardsFee) / 10000;
             // BananaVault fees are taken on withdraws
-            _safeBANANATransfer(settings.treasury, bananaFee);
+            _safeBANANATransfer(settings.platform, bananaFee);
             bananaToWithdraw -= bananaFee;
         }
 
@@ -604,7 +604,7 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
         if (_takeFee && settings.platformFee > 0) {
             // This catches times when banana is deposited outside of earn and harvests are generated
             uint256 bananaFee = (bananaBalance * settings.platformFee) / 10000;
-            _safeBANANATransfer(settings.treasury, bananaFee);
+            _safeBANANATransfer(settings.platform, bananaFee);
             bananaBalance -= bananaFee;
         }
 
@@ -756,7 +756,7 @@ abstract contract BaseBananaMaximizerStrategy is Ownable, ReentrancyGuard {
         strategySettings.platform = _platform;
     }
 
-    /// @notice set treasury address
+    /// @notice Set the treasury address where Keeper fees are sent to
     /// @param _treasury treasury address
     /// @param _useDefault usage of VaultApeMaximizer default
     /// @dev only owner

--- a/contracts/maximizer/MaximizerVaultApe.sol
+++ b/contracts/maximizer/MaximizerVaultApe.sol
@@ -414,7 +414,7 @@ contract MaximizerVaultApe is
         nonReentrant
     {
         address vaultAddress = vaults[_pid];
-        VaultInfo memory vaultInfo = vaultInfos[vaultAddress];
+        VaultInfo storage vaultInfo = vaultInfos[vaultAddress];
         require(vaultInfo.enabled, "MaximizerVaultApe: vault is disabled");
 
         IStrategyMaximizerMasterApe strat = IStrategyMaximizerMasterApe(
@@ -422,6 +422,8 @@ contract MaximizerVaultApe is
         );
         IERC20 wantToken = IERC20(strat.STAKE_TOKEN_ADDRESS());
         uint256 beforeWantToken = wantToken.balanceOf(address(strat));
+        // The vault will be compounded on each deposit
+        vaultInfo.lastCompound = block.timestamp;
         wantToken.safeTransferFrom(msg.sender, address(strat), _wantAmt);
         uint256 afterWantToken = wantToken.balanceOf(address(strat));
         // account for reflect fees
@@ -436,19 +438,22 @@ contract MaximizerVaultApe is
         override
         nonReentrant
     {
-        IStrategyMaximizerMasterApe strat = IStrategyMaximizerMasterApe(
-            vaults[_pid]
-        );
-        strat.withdraw(msg.sender, _wantAmt);
+        _withdraw(_pid, _wantAmt);
     }
 
     /// @notice User withdraw all for specific vault
     /// @param _pid pid of vault
     function withdrawAll(uint256 _pid) external override nonReentrant {
+        _withdraw(_pid, type(uint256).max);
+    }
+
+    /// @dev Providing a private withdraw as nonReentrant functions cannot call each other
+    function _withdraw(uint256 _pid, uint256 _wantAmt) private {
+        address vaultAddress = vaults[_pid];
         IStrategyMaximizerMasterApe strat = IStrategyMaximizerMasterApe(
-            vaults[_pid]
+            vaultAddress
         );
-        strat.withdraw(msg.sender, type(uint256).max);
+        strat.withdraw(msg.sender, _wantAmt);
     }
 
     /// @notice User harvest rewards for specific vault
@@ -527,6 +532,19 @@ contract MaximizerVaultApe is
             vaultAddress
         );
         strat.emergencyVaultWithdraw();
+        disableVault(_vaultPid);
+        emit VaultDisabled(_vaultPid, vaultAddress);
+    }
+
+    function emergencyBananaVaultWithdraw(
+        uint256 _vaultPid,
+        address _sendBananaTo
+    ) external onlyOwner {
+        address vaultAddress = vaults[_vaultPid];
+        IStrategyMaximizerMasterApe strat = IStrategyMaximizerMasterApe(
+            vaultAddress
+        );
+        strat.emergencyBananaVaultWithdraw(_sendBananaTo);
         disableVault(_vaultPid);
         emit VaultDisabled(_vaultPid, vaultAddress);
     }

--- a/contracts/maximizer/StrategyMaximizerMasterApe.sol
+++ b/contracts/maximizer/StrategyMaximizerMasterApe.sol
@@ -123,17 +123,11 @@ contract StrategyMaximizerMasterApe is BaseBananaMaximizerStrategy {
     {
         uint256 rewards = _rewardTokenBalance() +
             (STAKE_TOKEN_FARM.pendingCake(FARM_PID, address(this)));
-
-        if (_path.length <= 1 || rewards == 0) {
-            return rewards;
-        } else {
-            uint256[] memory amounts = router.getAmountsOut(rewards, _path);
-            return amounts[amounts.length - 1];
-        }
+        return _getExpectedOutputAmount(_path, rewards);
     }
 
     /// @notice Handle emergency withdraw of this strategy without caring about rewards. EMERGENCY ONLY.
-    function emergencyVaultWithdraw() public override onlyVaultApe {
+    function _emergencyVaultWithdraw() internal override {
         STAKE_TOKEN_FARM.emergencyWithdraw(FARM_PID);
     }
 

--- a/test/VaultApeMaximizerKeeper.test.js
+++ b/test/VaultApeMaximizerKeeper.test.js
@@ -310,9 +310,9 @@ describe('KeeperMaximizerVaultApe', function () {
       });
 
       it('should withdraw and pay withdraw fee', async () => {
-        const { treasury } = await strategyMaximizerMasterApe.getSettings();
-        const wantAccountSnapshotBefore = await getAccountTokenBalances(wantToken, [testerAddress, adminAddress, treasury]);
-        const bananaAccountSnapshotBefore = await getAccountTokenBalances(bananaToken, [testerAddress, adminAddress, treasury]);
+        const { platform } = await strategyMaximizerMasterApe.getSettings();
+        const wantAccountSnapshotBefore = await getAccountTokenBalances(wantToken, [testerAddress, adminAddress, platform]);
+        const bananaAccountSnapshotBefore = await getAccountTokenBalances(bananaToken, [testerAddress, adminAddress, platform]);
         await maximizerVaultApe.deposit(0, toDeposit, { from: testerAddress });
         // Snapshot Before
         const strategySnapshotBefore = await getStrategyMaximizerSnapshot(strategyMaximizerMasterApe, [testerAddress, testerAddress2]);
@@ -343,14 +343,14 @@ describe('KeeperMaximizerVaultApe', function () {
         userInfo = await maximizerVaultApe.userInfo(0, testerAddress);
         expect(Number(userInfo.stake)).equal(0, 'user stake is not zero after withdraw')
         // That the stake token of that vault increases for the tester by the amount less than the withdraw fee
-        const wantAccountSnapshotAfter = await getAccountTokenBalances(wantToken, [testerAddress, adminAddress, treasury]);
-        const bananaAccountSnapshotAfter = await getAccountTokenBalances(bananaToken, [testerAddress, adminAddress, treasury]);
+        const wantAccountSnapshotAfter = await getAccountTokenBalances(wantToken, [testerAddress, adminAddress, platform]);
+        const bananaAccountSnapshotAfter = await getAccountTokenBalances(bananaToken, [testerAddress, adminAddress, platform]);
         const withdrawFee = new BN(toDeposit).mul(new BN(2)).mul(new BN("25")).div(new BN("10000")); //0.25% withdraw fees
         const shouldBeBalance = new BN(wantAccountSnapshotBefore[testerAddress]).sub(withdrawFee);
 
         // Assert stake token balances
         expect(
-          new BN(wantAccountSnapshotAfter[treasury])
+          new BN(wantAccountSnapshotAfter[platform])
             .eq(withdrawFee))
           .equal(true, 'withdraw fee to treasury address inaccurate');
         expect(wantAccountSnapshotAfter[testerAddress]).equal(shouldBeBalance.toString(), 'user want balance inaccurate after withdraw');
@@ -362,9 +362,9 @@ describe('KeeperMaximizerVaultApe', function () {
           .equal(true, 'banana tokens did not increase for tester address after earn/withdraw');
         // NOTE: Only testing for value increases
         expect(
-          new BN(bananaAccountSnapshotAfter[treasury])
-            .gt(new BN(bananaAccountSnapshotBefore[treasury])))
-          .equal(true, 'banana tokens did not increase for treasury address after earn/reward withdraw fee');
+          new BN(bananaAccountSnapshotAfter[platform])
+            .gt(new BN(bananaAccountSnapshotBefore[platform])))
+          .equal(true, 'banana tokens did not increase for platform after earn/reward withdraw fee');
 
         userInfo = await maximizerVaultApe.userInfo(0, testerAddress);
 
@@ -505,7 +505,7 @@ describe('KeeperMaximizerVaultApe', function () {
         expect(wantBalanceAfter.toString()).equal(shouldBeBalance.toString());
 
         // TODO: This test is failing?
-        expect(Number(bananaBalanceAfter1 - bananaBalanceBefore1)).to.be.greaterThan(Number(accSharesPerStakedToken * 0.99 * (toDeposit / 1e18))); //0.99 = 1% withdral rewards fee
+        expect(Number(bananaBalanceAfter1 - bananaBalanceBefore1)).to.be.greaterThan(Number(accSharesPerStakedToken * 0.99 * (toDeposit / 1e18))); //0.99 = 1% withdraw rewards fee
         expect(Number(bananaBalanceAfter1)).to.be.greaterThan(Number(bananaBalanceBefore1));
         expect(Number(bananaBalanceAfter2)).to.be.greaterThan(Number(bananaBalanceBefore2));
 
@@ -513,12 +513,12 @@ describe('KeeperMaximizerVaultApe', function () {
       });
 
       it('should harvest properly', async () => {
-        const { treasury } = await strategyMaximizerMasterApe.getSettings();
-        const bananaAccountSnapshotBefore = await getAccountTokenBalances(bananaToken, [testerAddress, adminAddress, treasury]);
+        const { platform } = await strategyMaximizerMasterApe.getSettings();
+        const bananaAccountSnapshotBefore = await getAccountTokenBalances(bananaToken, [testerAddress, adminAddress, platform]);
         // Deposit tokens
         await maximizerVaultApe.deposit(0, toDeposit, { from: testerAddress });
         // Snapshot Before
-        const strategySnapshotBefore = await getStrategyMaximizerSnapshot(strategyMaximizerMasterApe, [testerAddress, testerAddress2, treasury]);
+        const strategySnapshotBefore = await getStrategyMaximizerSnapshot(strategyMaximizerMasterApe, [testerAddress, testerAddress2, platform]);
         const bananaVaultSnapshotBefore = await getBananaVaultSnapshot(bananaVault, [strategyMaximizerMasterApe.address]);
         const userInfo = await maximizerVaultApe.userInfo(0, testerAddress);
 
@@ -530,7 +530,7 @@ describe('KeeperMaximizerVaultApe', function () {
         await advanceNumBlocks(blocksToAdvance);
         await maximizerVaultApe.earn(0);
         const bananaVaultSnapshotInBetween = await getBananaVaultSnapshot(bananaVault, [strategyMaximizerMasterApe.address]);
-        const strategySnapshotInBetween = await getStrategyMaximizerSnapshot(strategyMaximizerMasterApe, [testerAddress, testerAddress2, treasury]);
+        const strategySnapshotInBetween = await getStrategyMaximizerSnapshot(strategyMaximizerMasterApe, [testerAddress, testerAddress2, platform]);
         // NOTE: Only testing for value increases
         // balanceOf evaluates the current banana value, while userInfo stores the most recent state update (will be behind)
         expect(
@@ -553,7 +553,7 @@ describe('KeeperMaximizerVaultApe', function () {
 
         const strategySnapshotAfter = await getStrategyMaximizerSnapshot(strategyMaximizerMasterApe, [testerAddress, testerAddress2]);
         const bananaVaultSnapshotAfter = await getBananaVaultSnapshot(bananaVault, [strategyMaximizerMasterApe.address]);
-        const bananaAccountSnapshotAfter = await getAccountTokenBalances(bananaToken, [testerAddress, adminAddress, treasury]);
+        const bananaAccountSnapshotAfter = await getAccountTokenBalances(bananaToken, [testerAddress, adminAddress, platformAddress]);
 
         // NOTE: Only testing for value decreases
         expect(
@@ -575,14 +575,14 @@ describe('KeeperMaximizerVaultApe', function () {
           .equal(true, 'banana tokens did not increase for tester address after earn/withdraw');
         // NOTE: Only testing for value increases
         expect(
-          new BN(bananaAccountSnapshotAfter[treasury])
-            .gt(new BN(bananaAccountSnapshotBefore[treasury])))
-          .equal(true, 'banana tokens did not increase for treasury address after earn/reward withdraw fee');
+          new BN(bananaAccountSnapshotAfter[platform])
+            .gt(new BN(bananaAccountSnapshotBefore[platform])))
+          .equal(true, 'banana tokens did not increase for platform after earn/reward withdraw fee');
         // NOTE: Only testing for value increases
         expect(
-          new BN(bananaAccountSnapshotAfter[treasury])
-            .gt(new BN(bananaAccountSnapshotBefore[treasury])))
-          .equal(true, 'banana tokens did not increase for treasury address after earn/reward withdraw fee');
+          new BN(bananaAccountSnapshotAfter[platform])
+            .gt(new BN(bananaAccountSnapshotBefore[platform])))
+          .equal(true, 'banana tokens did not increase for platform after earn/reward withdraw fee');
       });
 
       // One pass tests
@@ -675,10 +675,12 @@ describe('KeeperMaximizerVaultApe', function () {
 
       it('should be able to emergency withdraw', async () => {
         await maximizerVaultApe.deposit(0, toDeposit, { from: testerAddress })
+        await time.advanceBlock();
+        maximizerVaultApe.earn(0, { from: testerAddress });
         const vaultAddress = await maximizerVaultApe.vaults(0);
         let wantBalanceVault = await wantToken.balanceOf(vaultAddress);
         expect(wantBalanceVault.toString()).equal("0")
-        
+
         await maximizerVaultApe.emergencyVaultWithdraw(0, { from: adminAddress })
         let vaultInfo = await maximizerVaultApe.vaultInfos(vaultAddress);
         expect(vaultInfo.enabled).to.be.false;
@@ -700,6 +702,14 @@ describe('KeeperMaximizerVaultApe', function () {
         await maximizerVaultApe.enableVault(0, { from: adminAddress })
         vaultInfo = await maximizerVaultApe.vaultInfos(vaultAddress);
         expect(vaultInfo.enabled).to.be.true;
+
+        // Test Emergency Withdraw on BANANA Vault
+        const toAddress = accounts[9];
+        const bananaSnapshotBefore = await getAccountTokenBalances(bananaToken, [toAddress]);
+        await maximizerVaultApe.emergencyBananaVaultWithdraw(0, toAddress, { from: adminAddress })
+        const bananaSnapshotAfter = await getAccountTokenBalances(bananaToken, [toAddress]);
+        expect(Number(bananaSnapshotAfter[toAddress])).to.be.greaterThan(Number(bananaSnapshotBefore[toAddress]), 'emergencyBananaVaultWithdraw did not send tokens')
+
       });
 
       it('should have correct values for view functions', async () => {


### PR DESCRIPTION
- Change _farm var to more explicit naming
- Added emergencyBananaVaultWithdraw
- On withdrawAll take all rewards out of banana vault and not strat (those are not allocated yet)
- On deposit only allocate rewards to current staked tokens
- Update lastCompound on deposit